### PR TITLE
Fix/autoconfig after start

### DIFF
--- a/consumer/app/main.py
+++ b/consumer/app/main.py
@@ -177,6 +177,7 @@ class ESConsumerManager(object):
                       i not in self.autoconfigured_topics]
         except Exception as ke:
             log.error('Autoconfig failed to get available topics \n%s' % (ke))
+            return []  # Can't auto-configure if Kafka isn't available
         geo_point = (
             autoconf.get('geo_point_name', None)
             if autoconf.get('geo_point_creation', False)

--- a/consumer/entrypoint.sh
+++ b/consumer/entrypoint.sh
@@ -50,7 +50,7 @@ case "$1" in
     pip_freeze )
 
         rm -rf /tmp/env
-        pip3 install -f ./conf/pip/dependencies -r ./conf/pip/primary-requirements.txt --upgrade
+        pip3 install -r ./conf/pip/primary-requirements.txt --upgrade
 
         cat /code/conf/pip/requirements_header.txt | tee conf/pip/requirements.txt
         pip freeze --local | grep -v appdir | tee -a conf/pip/requirements.txt

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -29,7 +29,7 @@ services:
       - ./consumer/tests:/code/tests
     environment:
       ELASTICSEARCH_PORT: 9200
-      KAFKA_URL: "kafka-test:29099"
+      KAFKA_URL: "kafka-test:29092"
       CONSUMER_PORT: 9099
       LOG_LEVEL: "ERROR"
       ES_CONSUMER_CONFIG_PATH: "/code/tests/conf/consumer.json"


### PR DESCRIPTION
If Kafka became unavailable after steady-state the Thread running the auto-config lookup would die. 