### PR TITLE
fix: give better alternative to dotted names for Kafka config

### DIFF
--- a/consumer/app/artifacts.py
+++ b/consumer/app/artifacts.py
@@ -287,7 +287,7 @@ class ESJob(BaseJob):
         self._previous_topics = []
         self.log_stack = []
         self.log = callback_logger('JOB', self.log_stack, 100)
-        self.group_name = f'{self.tenant}.{self._id}'
+        self.group_name = f'{self.tenant}.esconsumer.{self._id}'
         self.sleep_delay: float = 0.5
         self.report_interval: int = 100
         args = {k.lower(): v for k, v in KAFKA_CONFIG.copy().items()}

--- a/consumer/app/config.py
+++ b/consumer/app/config.py
@@ -75,14 +75,20 @@ def load_config():
 def get_kafka_config():
     # load security settings in from environment
     # if the security protocol is set
-    if kafka_config.get('SECURITY.PROTOCOL'):
-        for i in [
-            'SECURITY.PROTOCOL',
-            'SASL.MECHANISM',
-            'SASL.USERNAME',
-            'SASL.PASSWORD'
+    protocol = kafka_config.get('SECURITY.PROTOCOL') or \
+        kafka_config.get('KAFKA_CONSUMER_SECURITY_PROTOCOL')
+    if protocol:
+        for name, alias in [
+            ('SECURITY.PROTOCOL', 'KAFKA_CONSUMER_SECURITY_PROTOCOL'),
+            ('SASL.MECHANISM', 'KAFKA_CONSUMER_SASL_MECHANISM'),
+            ('SASL.USERNAME', 'KAFKA_CONSUMER_USER'),
+            ('SASL.PASSWORD', 'KAFKA_CONSUMER_PASSWORD')
         ]:
-            kafka_config[i] = kafka_config.get(i)
+            if not kafka_config.get(name):
+                kafka_config[name] = kafka_config.get(alias)
+            else:
+                kafka_config[name] = kafka_config.get(name)
+    print(kafka_config)
     return kafka_config
 
 

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -15,28 +15,26 @@ services:
       REDIS_DB: 0
       REDIS_HOST: localhost
       REDIS_PORT: 6379
-      REDIS_PASSWORD: password
-      
+      # REDIS_PASSWORD: password
       CONSUMER_NAME: 'ES-TEST'
-      
+
       KIBANA_URL: http://kibana:5601/kibana-app
       ELASTICSEARCH_URL: elasticsearch:9200
       ELASTICSEARCH_USER: admin
       ELASTICSEARCH_PASSWORD: admin
-      
+
       KAFKA_URL: ${KAFKA_URL}
       SECURITY.PROTOCOL: SASL_SSL
       SASL.MECHANISM: PLAIN
-      SASL.USERNAME: ${KAFKA_SASL_USERNAME}
-      SASL.PASSWORD: ${KAFKA_SASL_PASSWORD}
-      
+      KAFKA_CONSUMER_USER: ${KAFKA_SASL_USERNAME}
+      KAFKA_CONSUMER_PASSWORD: ${KAFKA_SASL_PASSWORD}
+
       EXPOSE_PORT: 9013
       LOG_LEVEL: "DEBUG"
       ES_CONSUMER_CONFIG_PATH: "/code/tests/conf/consumer.json"
       ES_CONSUMER_KAFKA_CONFIG_PATH: "/code/tests/conf/kafka.json"
       CONNECT_RETRY_WAIT: 1
       STARTUP_CONNECTION_RETRY: 3
-    
 
   elasticsearch:
     image: amazon/opendistro-for-elasticsearch:${AMAZON_ES_VERSION:-1.2.1}
@@ -48,7 +46,6 @@ services:
       - ./conf/security.yml:/usr/share/elasticsearch/plugins/opendistro_security/securityconfig/config.yml
     ports:
       - 9200:9200
-
 
   kibana:
     image: amazon/opendistro-for-elasticsearch-kibana:${AMAZON_ES_VERSION:-1.2.1}
@@ -65,3 +62,11 @@ services:
       - elasticsearch
     ports:
       - 5601:5601
+
+  redis:
+    image: redis:alpine
+    # environment:
+    #   EXPOSE_PORT: 6379
+    #   LOG_LEVEL: debug
+    # ports:
+    #   - 6379:6379

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -21,6 +21,6 @@
 
 set -Eeuo pipefail
 
-docker-compose -f ./docker-compose-test.yml up -d elasticsearch kibana
+docker-compose -f ./docker-compose-test.yml up -d elasticsearch kibana redis
 docker-compose -f ./docker-compose-test.yml run --rm consumer-test test_integration
 docker-compose -f docker-compose-test.yml down

--- a/scripts/run_travis.sh
+++ b/scripts/run_travis.sh
@@ -20,6 +20,6 @@
 #
 set -Eeuo pipefail
 
-docker-compose -f ./docker-compose-test.yml up -d elasticsearch kibana
+docker-compose -f ./docker-compose-test.yml up -d elasticsearch kibana redis
 scripts/run_unit_tests.sh
 scripts/run_integration_tests.sh

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -20,5 +20,7 @@
 #
 set -Eeuo pipefail
 
-
+docker-compose -f docker-compose-test.yml up -d redis
 docker-compose -f docker-compose-test.yml run --rm consumer-test test_unit
+docker-compose -f docker-compose-test.yml kill redis
+docker-compose -f docker-compose-test.yml rm -f redis


### PR DESCRIPTION
Fix an issues with Kubernetes / Helm deploys where kafka credentials could not be passed easily by environment.