### PR TITLE
fix: issue using lstrip to remove tenants that end with the same lett…

### DIFF
--- a/consumer/app/artifacts.py
+++ b/consumer/app/artifacts.py
@@ -244,7 +244,7 @@ class Subscription(BaseResource):
     def _handles_topic(self, topic, tenant):
         topic_str = self.definition.topic_pattern
         # remove tenant information
-        no_tenant = topic.lstrip(f'{tenant}.')
+        no_tenant = topic[:].replace(f'{tenant}.', '', 1)
         return fnmatch.fnmatch(no_tenant, topic_str)
 
 

--- a/consumer/tests/__init__.py
+++ b/consumer/tests/__init__.py
@@ -48,6 +48,7 @@ from aether.python.avro.schema import Node
 from app import config
 from app.fixtures import examples
 from app.processor import ESItemProcessor
+from app.artifacts import Subscription
 
 from app import consumer
 
@@ -220,6 +221,13 @@ def RequestClientT2():
 @pytest.fixture(scope='session')
 def SubscriptionDefinition():
     return examples.SUBSCRIPTION
+
+
+@pytest.mark.unit
+@pytest.mark.integration
+@pytest.fixture(scope='function')
+def MockSubscription(SubscriptionDefinition):
+    yield Subscription(TENANT, SubscriptionDefinition)
 
 
 @pytest.mark.unit

--- a/consumer/tests/test_unit.py
+++ b/consumer/tests/test_unit.py
@@ -114,3 +114,16 @@ def test__merge_dicts():
     ]
     for a, b, c in cases:
         assert(utils.merge_dicts(a, b) == c)
+
+
+@pytest.mark.unit
+def test__subscription_handles_topic(MockSubscription):
+    tests = [
+        ('abc', 'cde', 'abc.cde', True),
+        ('abc', 'cd*', 'abc.cde', True),
+        ('abc', 'cde', 'abc.bde', False)
+    ]
+    for tenant, topic_pattern, test, xpct in tests:
+        MockSubscription.tenant = tenant
+        MockSubscription.definition['topic_pattern'] = topic_pattern
+        assert MockSubscription._handles_topic(test, tenant) is xpct


### PR DESCRIPTION
fix: issue using lstrip to remove tenants that end with the same letter that the topic begins with