### PR TITLE
fix: autotimestamp in sub should be a string

### DIFF
--- a/consumer/app/fixtures/examples.py
+++ b/consumer/app/fixtures/examples.py
@@ -58,7 +58,7 @@ SUBSCRIPTION = {
     },
     'es_options': {
         'alias_name': 'test',
-        'auto_timestamp': True,
+        'auto_timestamp': 'aes_ts',
         'geo_point_creation': True,
         'geo_point_name': 'geopoint'
     },

--- a/consumer/app/fixtures/schemas.py
+++ b/consumer/app/fixtures/schemas.py
@@ -370,11 +370,10 @@ SUBSCRIPTION = '''
         },
         "auto_timestamp": {
           "$id": "#/properties/es_options/properties/auto_timestamp",
-          "type": "boolean",
+          "type": ["null", "string", "boolean"],
           "title": "The Auto_timestamp Schema",
-          "default": false,
           "examples": [
-            true
+            "my-timestamp"
           ]
         },
         "geo_point_creation": {


### PR DESCRIPTION
Still allows bools for backwards compat.